### PR TITLE
Fix mandala drag alignment

### DIFF
--- a/src/components/MandalaEditor.tsx
+++ b/src/components/MandalaEditor.tsx
@@ -74,7 +74,7 @@ export function MandalaEditor() {
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [frame, setFrame] = useState<FrameMode>("none")
   const [broken, setBroken] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLDivElement>(null)
   const [draggingId, setDraggingId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -112,8 +112,8 @@ export function MandalaEditor() {
   }
 
   const handlePointerMove = (event: PointerEvent) => {
-    if (!draggingId || !containerRef.current) return
-    const bounds = containerRef.current.getBoundingClientRect()
+    if (!draggingId || !canvasRef.current) return
+    const bounds = canvasRef.current.getBoundingClientRect()
     const x = event.clientX - bounds.left
     const y = event.clientY - bounds.top
     const center = CANVAS_SIZE / 2
@@ -229,7 +229,6 @@ export function MandalaEditor() {
           </p>
         </BinderPanel>
         <div
-          ref={containerRef}
           className="relative mx-auto w-full max-w-[640px] overflow-hidden rounded-[2.5rem] border border-border/60 bg-stone-soft/30 p-6"
           style={{ height: CANVAS_SIZE + 48 }}
         >
@@ -287,7 +286,9 @@ export function MandalaEditor() {
               </svg>
             )}
           </div>
-          <div className="absolute left-6 top-6"
+          <div
+            ref={canvasRef}
+            className="absolute left-6 top-6"
             style={{ width: CANVAS_SIZE, height: CANVAS_SIZE }}
           >
             <AnimatePresence>


### PR DESCRIPTION
## Summary
- attach a ref to the mandala canvas container so drag math uses the true canvas bounds
- guard the pointer move handler against a missing canvas element while keeping the same canvas center

## Testing
- npm run lint *(fails: existing lint issues in unrelated files and a missing dependency warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ce24a673d4832f8fc6765bb1ecb799