### PR TITLE
Add sacred geometry backdrops to Virmana forge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,14 @@ import AlphabetPage from "@/pages/Alphabet"
 import BuilderPage from "@/pages/Builder"
 import HomePage from "@/pages/Home"
 import MandalaPage from "@/pages/Mandala"
+import VirmanaPage from "@/pages/Virmana"
 
 const links = [
   { to: "/", label: "Home" },
   { to: "/alphabet", label: "Alphabet" },
   { to: "/builder", label: "Script Builder" },
   { to: "/mandala", label: "Mandala" },
+  { to: "/virmana", label: "Virmana" },
 ]
 
 export default function App() {
@@ -65,6 +67,7 @@ export default function App() {
           <Route path="/alphabet" element={<AlphabetPage />} />
           <Route path="/builder" element={<BuilderPage />} />
           <Route path="/mandala" element={<MandalaPage />} />
+          <Route path="/virmana" element={<VirmanaPage />} />
         </Routes>
       </main>
       <Separator className="mt-12" />

--- a/src/components/VirmanaForge.tsx
+++ b/src/components/VirmanaForge.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useMemo, useState } from "react"
+import { RotateCcw, Sparkles } from "lucide-react"
+
+import { ExportBar } from "@/components/ExportBar"
+import { RuneCanvas } from "@/components/RuneCanvas"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import type { RuneDef } from "@/lib/data/runes"
+import { findRuneByLatin } from "@/lib/data/runes"
+import {
+  VIRMANA_CANVAS_SIZE,
+  buildPlacements,
+  buildVirmanaSvg,
+  computeConnections,
+  computeRingRadii,
+  type VirmanaBackdropShape,
+  type VirmanaConnectionOptions,
+} from "@/lib/glyph/virmana"
+import { VIRMANA_PATTERNS } from "@/lib/glyph/virmana-patterns"
+import { polarToCartesian } from "@/lib/glyph/mandala"
+import { downloadAsFile, svgToPng } from "@/lib/utils"
+
+const SPOKE_OPTIONS = [6, 8, 10, 12, 16]
+const RING_OPTIONS = [2, 3, 4]
+const BASE_PATTERN = VIRMANA_PATTERNS[0]
+
+function sanitizeText(value: string) {
+  return value.toUpperCase().replace(/[^A-Z—]/g, "")
+}
+
+function uniqueById(runes: RuneDef[]): RuneDef[] {
+  const seen = new Set<string>()
+  return runes.filter((rune) => {
+    if (seen.has(rune.id)) {
+      return false
+    }
+    seen.add(rune.id)
+    return true
+  })
+}
+
+function renderBackdropShape(shape: VirmanaBackdropShape, key: string) {
+  switch (shape.type) {
+    case "circle":
+      return (
+        <circle
+          key={key}
+          cx={shape.cx}
+          cy={shape.cy}
+          r={shape.r}
+          stroke={shape.stroke}
+          strokeWidth={shape.strokeWidth}
+          strokeDasharray={shape.dashArray}
+          strokeLinecap={shape.strokeLinecap}
+          fill={shape.fill ?? "none"}
+          opacity={shape.opacity}
+        />
+      )
+    case "line":
+      return (
+        <line
+          key={key}
+          x1={shape.x1}
+          y1={shape.y1}
+          x2={shape.x2}
+          y2={shape.y2}
+          stroke={shape.stroke}
+          strokeWidth={shape.strokeWidth}
+          strokeDasharray={shape.dashArray}
+          strokeLinecap={shape.strokeLinecap}
+          opacity={shape.opacity}
+        />
+      )
+    case "polygon":
+      return (
+        <polygon
+          key={key}
+          points={shape.points.map((point) => `${point.x},${point.y}`).join(" ")}
+          stroke={shape.stroke}
+          strokeWidth={shape.strokeWidth}
+          strokeDasharray={shape.dashArray}
+          strokeLinecap={shape.strokeLinecap}
+          fill={shape.fill ?? "none"}
+          opacity={shape.opacity}
+        />
+      )
+    case "rect":
+      return (
+        <rect
+          key={key}
+          x={shape.x}
+          y={shape.y}
+          width={shape.width}
+          height={shape.height}
+          stroke={shape.stroke}
+          strokeWidth={shape.strokeWidth}
+          strokeDasharray={shape.dashArray}
+          strokeLinecap={shape.strokeLinecap}
+          fill={shape.fill ?? "none"}
+          opacity={shape.opacity}
+          rx={shape.rx}
+          ry={shape.ry}
+        />
+      )
+    case "path":
+      return (
+        <path
+          key={key}
+          d={shape.d}
+          stroke={shape.stroke}
+          strokeWidth={shape.strokeWidth}
+          strokeDasharray={shape.dashArray}
+          strokeLinecap={shape.strokeLinecap}
+          fill={shape.fill ?? "none"}
+          opacity={shape.opacity}
+        />
+      )
+    case "text":
+      return (
+        <text
+          key={key}
+          x={shape.x}
+          y={shape.y}
+          fill={shape.fill ?? "rgba(226,232,240,0.85)"}
+          opacity={shape.opacity}
+          fontSize={shape.fontSize}
+          fontWeight={shape.fontWeight}
+          letterSpacing={shape.letterSpacing}
+          textAnchor={shape.align}
+          dominantBaseline={shape.baseline}
+          fontFamily={shape.fontFamily}
+        >
+          {shape.text}
+        </text>
+      )
+    default:
+      return null
+  }
+}
+
+export function VirmanaForge() {
+  const patternDefaults = BASE_PATTERN.defaults ?? {}
+  const [patternId, setPatternId] = useState(BASE_PATTERN.id)
+  const [phrase, setPhrase] = useState("VIRMANA")
+  const [spokes, setSpokes] = useState<number>(patternDefaults.spokes ?? 12)
+  const [rings, setRings] = useState<number>(patternDefaults.rings ?? 3)
+  const [rotation, setRotation] = useState<number>(patternDefaults.rotation ?? 0)
+  const [deduplicate, setDeduplicate] = useState(patternDefaults.deduplicate ?? true)
+  const [traceSequence, setTraceSequence] = useState(patternDefaults.traceSequence ?? true)
+  const [weaveRings, setWeaveRings] = useState(patternDefaults.weaveRings ?? true)
+  const [mirror, setMirror] = useState(patternDefaults.mirror ?? true)
+  const [axis, setAxis] = useState(patternDefaults.axis ?? false)
+
+  const sanitized = useMemo(() => sanitizeText(phrase), [phrase])
+
+  const pattern = useMemo(
+    () => VIRMANA_PATTERNS.find((item) => item.id === patternId) ?? BASE_PATTERN,
+    [patternId],
+  )
+
+  useEffect(() => {
+    const defaults = pattern.defaults ?? {}
+    if (defaults.spokes !== undefined) setSpokes(defaults.spokes)
+    if (defaults.rings !== undefined) setRings(defaults.rings)
+    if (defaults.rotation !== undefined) setRotation(defaults.rotation)
+    if (defaults.deduplicate !== undefined) setDeduplicate(defaults.deduplicate)
+    if (defaults.traceSequence !== undefined) setTraceSequence(defaults.traceSequence)
+    if (defaults.weaveRings !== undefined) setWeaveRings(defaults.weaveRings)
+    if (defaults.mirror !== undefined) setMirror(defaults.mirror)
+    if (defaults.axis !== undefined) setAxis(defaults.axis)
+  }, [pattern])
+
+  const runeList = useMemo(() => {
+    const runes = sanitized
+      .split("")
+      .map((char) => findRuneByLatin(char))
+      .filter((rune): rune is RuneDef => Boolean(rune))
+    return deduplicate ? uniqueById(runes) : runes
+  }, [sanitized, deduplicate])
+
+  const layout = useMemo(() => buildPlacements(runeList, { rings, spokes, rotation }), [runeList, rings, spokes, rotation])
+
+  const connectionOptions = useMemo<VirmanaConnectionOptions>(
+    () => ({ traceSequence, weaveRings, mirror, axis }),
+    [traceSequence, weaveRings, mirror, axis],
+  )
+
+  const connections = useMemo(() => computeConnections(layout, connectionOptions), [layout, connectionOptions])
+
+  const ringRadii = useMemo(() => computeRingRadii(rings, VIRMANA_CANVAS_SIZE), [rings])
+  const center = layout.center
+  const includeGrid = pattern.showGrid ?? true
+  const accentColor = pattern.accent ?? "hsl(var(--primary))"
+
+  const patternShapes = useMemo(
+    () =>
+      pattern.build({
+        canvas: VIRMANA_CANVAS_SIZE,
+        center,
+        ringRadii,
+        options: { rings, spokes, rotation },
+      }),
+    [pattern, center, ringRadii, rings, spokes, rotation],
+  )
+
+  const backdropElements = useMemo(
+    () => patternShapes.map((shape, index) => renderBackdropShape(shape, `${pattern.id}-${index}`)),
+    [patternShapes, pattern.id],
+  )
+
+  const handleExportSvg = () => {
+    const svg = buildVirmanaSvg(layout, { rings, spokes, rotation }, connections, {
+      backdrop: patternShapes,
+      includeGrid,
+    })
+    downloadAsFile(`virmana-${sanitized || "silence"}.svg`, svg)
+  }
+
+  const handleExportPng = async () => {
+    const svg = buildVirmanaSvg(layout, { rings, spokes, rotation }, connections, {
+      backdrop: patternShapes,
+      includeGrid,
+    })
+    const png = await svgToPng(svg, VIRMANA_CANVAS_SIZE, VIRMANA_CANVAS_SIZE)
+    const link = document.createElement("a")
+    link.href = png
+    link.download = `virmana-${sanitized || "silence"}.png`
+    link.click()
+  }
+
+  const reset = () => {
+    const defaults = BASE_PATTERN.defaults ?? {}
+    setPatternId(BASE_PATTERN.id)
+    setPhrase("VIRMANA")
+    setSpokes(defaults.spokes ?? 12)
+    setRings(defaults.rings ?? 3)
+    setRotation(defaults.rotation ?? 0)
+    setDeduplicate(defaults.deduplicate ?? true)
+    setTraceSequence(defaults.traceSequence ?? true)
+    setWeaveRings(defaults.weaveRings ?? true)
+    setMirror(defaults.mirror ?? true)
+    setAxis(defaults.axis ?? false)
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="text-base">Glyph seed</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="virmana-phrase">Seed phrase</Label>
+            <Input
+              id="virmana-phrase"
+              value={phrase}
+              onChange={(event) => setPhrase(event.target.value.toUpperCase())}
+              placeholder="Enter word or mantra"
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              Characters map to runes automatically. Unknown symbols are ignored.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="virmana-pattern">Sacred frame</Label>
+            <Select value={patternId} onValueChange={setPatternId}>
+              <SelectTrigger id="virmana-pattern">
+                <SelectValue placeholder="Choose a lattice" />
+              </SelectTrigger>
+              <SelectContent>
+                {VIRMANA_PATTERNS.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Swap between Flower of Life petals, Metatron cubes, yantras, graha squares, and temple mosaics.
+            </p>
+          </div>
+          <div className="grid gap-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="virmana-spokes">Spokes</Label>
+                <Select value={String(spokes)} onValueChange={(value) => setSpokes(Number(value))}>
+                  <SelectTrigger id="virmana-spokes">
+                    <SelectValue placeholder="Spokes" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SPOKE_OPTIONS.map((option) => (
+                      <SelectItem key={option} value={String(option)}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="virmana-rings">Rings</Label>
+                <Select value={String(rings)} onValueChange={(value) => setRings(Number(value))}>
+                  <SelectTrigger id="virmana-rings">
+                    <SelectValue placeholder="Rings" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RING_OPTIONS.map((option) => (
+                      <SelectItem key={option} value={String(option)}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="virmana-rotation">Rotation {rotation.toFixed(0)}°</Label>
+              <input
+                id="virmana-rotation"
+                type="range"
+                min={0}
+                max={60}
+                step={1}
+                value={rotation}
+                onChange={(event) => setRotation(Number(event.target.value))}
+                className="w-full accent-primary"
+              />
+            </div>
+          </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div>
+                <Label htmlFor="virmana-dedup" className="text-sm font-medium">
+                  Collapse duplicates
+                </Label>
+                <p className="text-xs text-muted-foreground">Keep only the first occurrence of each rune.</p>
+              </div>
+              <Switch
+                id="virmana-dedup"
+                checked={deduplicate}
+                onCheckedChange={setDeduplicate}
+                aria-label="Collapse duplicate runes"
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div>
+                <Label htmlFor="virmana-trace" className="text-sm font-medium">
+                  Trace sequence
+                </Label>
+                <p className="text-xs text-muted-foreground">Connect nodes in the order typed.</p>
+              </div>
+              <Switch
+                id="virmana-trace"
+                checked={traceSequence}
+                onCheckedChange={setTraceSequence}
+                aria-label="Trace rune sequence"
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div>
+                <Label htmlFor="virmana-ringweave" className="text-sm font-medium">
+                  Weave rings
+                </Label>
+                <p className="text-xs text-muted-foreground">Link runes sharing the same radius.</p>
+              </div>
+              <Switch
+                id="virmana-ringweave"
+                checked={weaveRings}
+                onCheckedChange={setWeaveRings}
+                aria-label="Weave ring connections"
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div>
+                <Label htmlFor="virmana-mirror" className="text-sm font-medium">
+                  Mirror network
+                </Label>
+                <p className="text-xs text-muted-foreground">Reflect lines across the vertical axis.</p>
+              </div>
+              <Switch
+                id="virmana-mirror"
+                checked={mirror}
+                onCheckedChange={setMirror}
+                aria-label="Mirror the network"
+              />
+            </div>
+            <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/20 p-3">
+              <div>
+                <Label htmlFor="virmana-axis" className="text-sm font-medium">
+                  Radiate to center
+                </Label>
+                <p className="text-xs text-muted-foreground">Anchor every rune back into the core.</p>
+              </div>
+              <Switch
+                id="virmana-axis"
+                checked={axis}
+                onCheckedChange={setAxis}
+                aria-label="Radiate to center"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button type="button" variant="outline" size="sm" onClick={reset} className="flex items-center gap-2">
+              <RotateCcw className="h-4 w-4" /> Reset
+            </Button>
+            <Badge variant="outline" className="flex items-center gap-1 text-xs">
+              <Sparkles className="h-3 w-3" /> Nodes {runeList.length}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="space-y-6">
+        <Card className="bg-muted/20">
+          <CardHeader>
+            <CardTitle className="text-base">Virmana lattice</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              The lattice projects each rune onto sacred rings and spokes. Sequenced links and mirrored traces condense a mantra
+              into a transport sigil.
+            </p>
+            <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-primary">{pattern.label}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{pattern.description}</p>
+            </div>
+          </CardContent>
+        </Card>
+        <div
+          className="relative mx-auto w-full max-w-[720px] overflow-hidden rounded-[2.5rem] border border-border/60 bg-stone-soft/30 p-6"
+          style={{ height: VIRMANA_CANVAS_SIZE + 48 }}
+        >
+          <svg width={VIRMANA_CANVAS_SIZE} height={VIRMANA_CANVAS_SIZE} className="rounded-[2rem] bg-gradient-to-br from-stone-soft/30 to-transparent">
+            <rect x={0} y={0} width={VIRMANA_CANVAS_SIZE} height={VIRMANA_CANVAS_SIZE} fill="rgba(12,12,16,0.78)" />
+            <circle cx={center} cy={center} r={center - 18} fill="rgba(15,15,19,0.78)" />
+            {backdropElements}
+            {includeGrid &&
+              ringRadii.map((radius) => (
+                <circle key={radius} cx={center} cy={center} r={radius} stroke="rgba(148,163,184,0.28)" strokeDasharray="14 12" fill="none" />
+              ))}
+            {includeGrid &&
+              Array.from({ length: spokes }, (_, index) => rotation + (index * 360) / spokes).map((angle) => {
+                const { x, y } = polarToCartesian({ radius: center - 48, angle }, { x: center, y: center })
+                return <line key={angle} x1={center} y1={center} x2={x} y2={y} stroke="rgba(148,163,184,0.25)" strokeDasharray="12 10" />
+              })}
+            {connections.map((connection, index) => (
+              <line
+                key={`${connection.start.x}-${connection.start.y}-${index}`}
+                x1={connection.start.x}
+                y1={connection.start.y}
+                x2={connection.end.x}
+                y2={connection.end.y}
+                stroke={accentColor}
+                strokeWidth={6}
+                strokeLinecap="round"
+                strokeOpacity={0.7}
+              />
+            ))}
+            <circle cx={center} cy={center} r={8} fill={accentColor} />
+          </svg>
+          <div className="absolute left-6 top-6" style={{ width: VIRMANA_CANVAS_SIZE, height: VIRMANA_CANVAS_SIZE }}>
+            {layout.placements.map((placement, index) => {
+              const { x, y } = polarToCartesian({ radius: placement.radius, angle: placement.angle }, { x: center, y: center })
+              const left = x - 60
+              const top = y - 60
+              return (
+                <div key={`${placement.rune.id}-${index}`} className="absolute" style={{ left, top }}>
+                  <RuneCanvas
+                    rune={placement.rune}
+                    size={120}
+                    strokeWidth={10}
+                    className="border-transparent bg-background/80"
+                    strokeColor={accentColor}
+                  />
+                </div>
+              )
+            })}
+            {layout.placements.length === 0 && (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Add runes by typing a seed phrase.
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <Badge variant="outline">{pattern.label}</Badge>
+          <Badge variant="holo">Spokes ×{spokes}</Badge>
+          <Badge variant="outline">Rings ×{rings}</Badge>
+          <Badge variant="outline">Rotation {rotation.toFixed(0)}°</Badge>
+          <Badge variant="outline">Connections {connections.length}</Badge>
+        </div>
+        <div className="flex items-center gap-3">
+          <ExportBar
+            onExportSvg={handleExportSvg}
+            onExportPng={handleExportPng}
+            disabled={layout.placements.length === 0}
+          />
+          <Button type="button" variant="ghost" onClick={reset}>
+            Reset layout
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/glyph/virmana-patterns.ts
+++ b/src/lib/glyph/virmana-patterns.ts
@@ -1,0 +1,692 @@
+import { polarToCartesian } from "@/lib/glyph/mandala"
+
+import {
+  VIRMANA_CANVAS_SIZE,
+  type VirmanaBackdropCircle,
+  type VirmanaBackdropLine,
+  type VirmanaBackdropPath,
+  type VirmanaBackdropPolygon,
+  type VirmanaBackdropRect,
+  type VirmanaBackdropShape,
+  type VirmanaBackdropText,
+  type VirmanaOptions,
+  type VirmanaPoint,
+} from "@/lib/glyph/virmana"
+
+export interface VirmanaPatternContext {
+  canvas: number
+  center: number
+  ringRadii: number[]
+  options: VirmanaOptions
+}
+
+export interface VirmanaPatternDefaults {
+  rings?: number
+  spokes?: number
+  rotation?: number
+  deduplicate?: boolean
+  traceSequence?: boolean
+  weaveRings?: boolean
+  mirror?: boolean
+  axis?: boolean
+}
+
+export interface VirmanaPattern {
+  id: string
+  label: string
+  description: string
+  defaults?: VirmanaPatternDefaults
+  showGrid?: boolean
+  accent?: string
+  build: (context: VirmanaPatternContext) => VirmanaBackdropShape[]
+}
+
+const DEG_TO_RAD = Math.PI / 180
+const SQRT_THREE = Math.sqrt(3)
+
+function circle(
+  cx: number,
+  cy: number,
+  r: number,
+  props: Omit<VirmanaBackdropCircle, "type" | "cx" | "cy" | "r"> = {},
+): VirmanaBackdropCircle {
+  return {
+    type: "circle",
+    cx,
+    cy,
+    r,
+    ...props,
+  }
+}
+
+function line(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  props: Omit<VirmanaBackdropLine, "type" | "x1" | "y1" | "x2" | "y2"> = {},
+): VirmanaBackdropLine {
+  return {
+    type: "line",
+    x1,
+    y1,
+    x2,
+    y2,
+    ...props,
+  }
+}
+
+function polygon(points: VirmanaPoint[], props: Omit<VirmanaBackdropPolygon, "type" | "points"> = {}): VirmanaBackdropPolygon {
+  return {
+    type: "polygon",
+    points,
+    ...props,
+  }
+}
+
+function rect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  props: Omit<VirmanaBackdropRect, "type" | "x" | "y" | "width" | "height"> = {},
+): VirmanaBackdropRect {
+  return {
+    type: "rect",
+    x,
+    y,
+    width,
+    height,
+    ...props,
+  }
+}
+
+function path(d: string, props: Omit<VirmanaBackdropPath, "type" | "d"> = {}): VirmanaBackdropPath {
+  return {
+    type: "path",
+    d,
+    ...props,
+  }
+}
+
+function text(
+  x: number,
+  y: number,
+  value: string,
+  props: Omit<VirmanaBackdropText, "type" | "x" | "y" | "text"> = {},
+): VirmanaBackdropText {
+  return {
+    type: "text",
+    x,
+    y,
+    text: value,
+    ...props,
+  }
+}
+
+function rotatePoint(point: VirmanaPoint, center: VirmanaPoint, angle: number): VirmanaPoint {
+  const rad = angle * DEG_TO_RAD
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  const translatedX = point.x - center.x
+  const translatedY = point.y - center.y
+  return {
+    x: center.x + translatedX * cos - translatedY * sin,
+    y: center.y + translatedX * sin + translatedY * cos,
+  }
+}
+
+function squarePoints(center: number, size: number, rotation = 0): VirmanaPoint[] {
+  const half = size / 2
+  const basePoints: VirmanaPoint[] = [
+    { x: center - half, y: center - half },
+    { x: center + half, y: center - half },
+    { x: center + half, y: center + half },
+    { x: center - half, y: center + half },
+  ]
+  if (rotation === 0) {
+    return basePoints
+  }
+  return basePoints.map((point) => rotatePoint(point, { x: center, y: center }, rotation))
+}
+
+function regularPolygon(center: number, radius: number, sides: number, rotation = -90): VirmanaPoint[] {
+  return Array.from({ length: sides }, (_, index) => {
+    const angle = rotation + (360 / sides) * index
+    return polarToCartesian({ radius, angle }, { x: center, y: center })
+  })
+}
+
+function buildFlowerOfLife(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center, canvas } = context
+  const circleRadius = canvas / 6.5
+  const spacing = circleRadius
+  const axialSize = spacing / SQRT_THREE
+  const range = 2
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(circle(center, center, center - 36, { stroke: "rgba(226,232,240,0.25)", strokeWidth: 2 }))
+
+  for (let q = -range; q <= range; q += 1) {
+    const rMin = Math.max(-range, -q - range)
+    const rMax = Math.min(range, -q + range)
+    for (let r = rMin; r <= rMax; r += 1) {
+      const x = center + axialSize * (Math.sqrt(3) * q + (Math.sqrt(3) / 2) * r)
+      const y = center + axialSize * (1.5 * r)
+      shapes.push(circle(x, y, circleRadius, { stroke: "rgba(241,245,249,0.7)", strokeWidth: 1.6, opacity: 0.9 }))
+    }
+  }
+
+  const angles = Array.from({ length: 6 }, (_, index) => index * 60)
+  angles.forEach((angle) => {
+    const { x, y } = polarToCartesian({ radius: circleRadius * 2, angle }, { x: center, y: center })
+    shapes.push(line(center, center, x, y, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.5, dashArray: "12 10" }))
+  })
+
+  return shapes
+}
+
+function buildMetatronCube(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const outerRadius = center - 108
+  const nodeRadius = outerRadius * 0.34
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(circle(center, center, outerRadius + 26, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 2.5 }))
+  shapes.push(circle(center, center, nodeRadius, { stroke: "rgba(148,163,184,0.4)", strokeWidth: 2 }))
+
+  const angles = Array.from({ length: 6 }, (_, index) => index * 60)
+  const points = angles.map((angle) => polarToCartesian({ radius: outerRadius, angle }, { x: center, y: center }))
+
+  points.forEach((point) => {
+    shapes.push(circle(point.x, point.y, nodeRadius / 2.2, { stroke: "rgba(96,165,250,0.7)", strokeWidth: 1.8 }))
+    shapes.push(line(center, center, point.x, point.y, { stroke: "rgba(96,165,250,0.4)", strokeWidth: 2 }))
+  })
+
+  shapes.push(polygon(points, { stroke: "rgba(226,232,240,0.55)", strokeWidth: 2.2 }))
+  const triangleA = [points[0], points[2], points[4]]
+  const triangleB = [points[1], points[3], points[5]]
+  shapes.push(polygon(triangleA, { stroke: "rgba(244,244,245,0.65)", strokeWidth: 2.2 }))
+  shapes.push(polygon(triangleB, { stroke: "rgba(244,244,245,0.65)", strokeWidth: 2.2 }))
+
+  points.forEach((point, index) => {
+    const next = points[(index + 1) % points.length]
+    shapes.push(line(point.x, point.y, next.x, next.y, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.6 }))
+  })
+
+  for (let index = 0; index < points.length; index += 1) {
+    const second = points[(index + 2) % points.length]
+    shapes.push(line(points[index].x, points[index].y, second.x, second.y, { stroke: "rgba(56,189,248,0.45)", strokeWidth: 1.35 }))
+  }
+
+  return shapes
+}
+
+function buildTridentYantra(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const board = VIRMANA_CANVAS_SIZE * 0.62
+  const outerSquare = squarePoints(center, board, 45)
+  const innerSquare = squarePoints(center, board * 0.75)
+  const jewelSquare = squarePoints(center, board * 0.52, 45)
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(polygon(outerSquare, { stroke: "rgba(248,250,252,0.6)", strokeWidth: 3 }))
+  shapes.push(polygon(innerSquare, { stroke: "rgba(248,250,252,0.65)", strokeWidth: 2.6 }))
+  shapes.push(polygon(jewelSquare, { stroke: "rgba(250,250,250,0.7)", strokeWidth: 2.4 }))
+
+  shapes.push(circle(center, center, board * 0.28, { stroke: "rgba(248,250,252,0.75)", strokeWidth: 3.2 }))
+
+  shapes.push(line(center - board / 2.8, center, center + board / 2.8, center, { stroke: "rgba(244,244,245,0.45)", strokeWidth: 2.2 }))
+  shapes.push(line(center, center - board / 2.8, center, center + board / 2.8, { stroke: "rgba(244,244,245,0.45)", strokeWidth: 2.2 }))
+
+  const digitRadius = board * 0.34
+  const digits: { label: string; angle: number }[] = [
+    { label: "९", angle: -90 },
+    { label: "३", angle: -45 },
+    { label: "६", angle: 0 },
+    { label: "८", angle: 45 },
+    { label: "७", angle: 90 },
+    { label: "५", angle: 135 },
+    { label: "२", angle: 180 },
+    { label: "४", angle: -135 },
+  ]
+
+  digits.forEach((digit) => {
+    const { x, y } = polarToCartesian({ radius: digitRadius, angle: digit.angle }, { x: center, y: center })
+    shapes.push(text(x, y, digit.label, { fontSize: 26, fontWeight: "600", align: "middle", baseline: "middle", fontFamily: "'Noto Sans Devanagari', sans-serif" }))
+  })
+
+  shapes.push(text(center, center, "ॐ", { fontSize: 48, fontWeight: "700", align: "middle", baseline: "middle", fontFamily: "'Noto Sans Devanagari', sans-serif" }))
+
+  const gridSize = board * 0.18
+  const cell = gridSize / 3
+  const offsets = [
+    { x: -board * 0.5, y: -board * 0.5 },
+    { x: board * 0.5 - gridSize, y: -board * 0.5 },
+    { x: -board * 0.5, y: board * 0.5 - gridSize },
+    { x: board * 0.5 - gridSize, y: board * 0.5 - gridSize },
+  ]
+
+  offsets.forEach((offset) => {
+    const originX = center + offset.x
+    const originY = center + offset.y
+    shapes.push(rect(originX, originY, gridSize, gridSize, { stroke: "rgba(244,244,245,0.65)", strokeWidth: 1.6 }))
+    for (let i = 1; i < 3; i += 1) {
+      shapes.push(line(originX + cell * i, originY, originX + cell * i, originY + gridSize, { stroke: "rgba(244,244,245,0.45)", strokeWidth: 1.2 }))
+      shapes.push(line(originX, originY + cell * i, originX + gridSize, originY + cell * i, { stroke: "rgba(244,244,245,0.45)", strokeWidth: 1.2 }))
+    }
+  })
+
+  const tridentLength = board * 0.42
+  const tridentOffset = board * 0.11
+
+  const topY = center - tridentLength / 2 - tridentOffset
+  const bottomY = center + tridentLength / 2 + tridentOffset
+  const leftX = center - tridentLength / 2 - tridentOffset
+  const rightX = center + tridentLength / 2 + tridentOffset
+
+  shapes.push(line(center, topY, center, topY + tridentLength, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2.6, strokeLinecap: "round" }))
+  shapes.push(line(center, bottomY, center, bottomY - tridentLength, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2.6, strokeLinecap: "round" }))
+  shapes.push(line(leftX, center, leftX + tridentLength, center, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2.6, strokeLinecap: "round" }))
+  shapes.push(line(rightX, center, rightX - tridentLength, center, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2.6, strokeLinecap: "round" }))
+
+  const prong = board * 0.12
+
+  shapes.push(line(center, topY, center - prong, topY + prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(center, topY, center + prong, topY + prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(center, bottomY, center - prong, bottomY - prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(center, bottomY, center + prong, bottomY - prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(leftX, center, leftX + prong, center - prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(leftX, center, leftX + prong, center + prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(rightX, center, rightX - prong, center - prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+  shapes.push(line(rightX, center, rightX - prong, center + prong, { stroke: "rgba(248,250,252,0.7)", strokeWidth: 2 }))
+
+  return shapes
+}
+
+function buildArchitectMandala(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const outer = center - 42
+  const mid = outer * 0.78
+  const inner = outer * 0.56
+  const core = inner * 0.62
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(circle(center, center, outer, { stroke: "rgba(234,179,8,0.5)", strokeWidth: 2.6 }))
+  shapes.push(polygon(squarePoints(center, outer * 1.35, 45), { stroke: "rgba(250,204,21,0.35)", strokeWidth: 1.8 }))
+  shapes.push(polygon(squarePoints(center, outer * 1.05), { stroke: "rgba(253,224,71,0.45)", strokeWidth: 1.9 }))
+  shapes.push(polygon(squarePoints(center, mid, 45), { stroke: "rgba(250,250,210,0.55)", strokeWidth: 1.8 }))
+  shapes.push(polygon(squarePoints(center, inner), { stroke: "rgba(254,240,138,0.65)", strokeWidth: 1.7 }))
+  shapes.push(polygon(squarePoints(center, inner * 0.82, 45), { stroke: "rgba(254,240,138,0.45)", strokeWidth: 1.4 }))
+  shapes.push(circle(center, center, core * 0.7, { stroke: "rgba(250,250,250,0.5)", strokeWidth: 1.6 }))
+
+  const spokes = 24
+  for (let index = 0; index < spokes; index += 1) {
+    const angle = index * (360 / spokes)
+    const outerPoint = polarToCartesian({ radius: inner * 0.95, angle }, { x: center, y: center })
+    const innerPoint = polarToCartesian({ radius: core * 0.55, angle }, { x: center, y: center })
+    shapes.push(line(innerPoint.x, innerPoint.y, outerPoint.x, outerPoint.y, { stroke: "rgba(253,224,71,0.4)", strokeWidth: 1.35 }))
+  }
+
+  const starPoints = regularPolygon(center, inner * 0.68, 12)
+  shapes.push(polygon(starPoints, { stroke: "rgba(252,211,77,0.5)", strokeWidth: 1.4 }))
+
+  const tickCount = 36
+  const tickRadius = inner * 1.12
+  const tickLength = 12
+  for (let index = 0; index < tickCount; index += 1) {
+    const angle = index * (360 / tickCount)
+    const start = polarToCartesian({ radius: tickRadius - tickLength, angle }, { x: center, y: center })
+    const end = polarToCartesian({ radius: tickRadius, angle }, { x: center, y: center })
+    shapes.push(line(start.x, start.y, end.x, end.y, { stroke: "rgba(234,179,8,0.35)", strokeWidth: 1.1 }))
+  }
+
+  const squarePointsSet = squarePoints(center, core, 45)
+  shapes.push(polygon(squarePointsSet, { stroke: "rgba(255,255,255,0.55)", strokeWidth: 1.4 }))
+  shapes.push(circle(center, center, core * 0.5, { stroke: "rgba(255,255,255,0.45)", strokeWidth: 1.2 }))
+
+  const anchorRadius = core * 0.68
+  for (let index = 0; index < 4; index += 1) {
+    const angle = index * 90 - 45
+    const { x, y } = polarToCartesian({ radius: anchorRadius, angle }, { x: center, y: center })
+    shapes.push(rect(x - 6, y - 6, 12, 12, { fill: "rgba(253,224,71,0.75)", stroke: "rgba(250,250,250,0.6)", strokeWidth: 1 }))
+  }
+
+  return shapes
+}
+
+const navDurgaCells = [
+  { row: 0, col: 0, number: "EIGHT", title: "Mahagori" },
+  { row: 0, col: 1, number: "ONE", title: "Shelputri" },
+  { row: 0, col: 2, number: "SIX", title: "Katyayani" },
+  { row: 1, col: 0, number: "THREE", title: "Chandraghanta" },
+  { row: 1, col: 1, number: "FIVE", title: "Skandamata" },
+  { row: 1, col: 2, number: "SEVEN", title: "Kalaratri" },
+  { row: 2, col: 0, number: "FOUR", title: "Kushmanda" },
+  { row: 2, col: 1, number: "NINE", title: "Siddhidatri" },
+  { row: 2, col: 2, number: "TWO", title: "Brahmacharini" },
+]
+
+function buildNavDurgaGrid(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const board = VIRMANA_CANVAS_SIZE * 0.55
+  const cell = board / 3
+  const originX = center - board / 2
+  const originY = center - board / 2
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(rect(originX - 12, originY - 12, board + 24, board + 24, { stroke: "rgba(226,232,240,0.35)", strokeWidth: 2.2, fill: "rgba(15,15,19,0.55)" }))
+  shapes.push(rect(originX, originY, board, board, { stroke: "rgba(241,245,249,0.65)", strokeWidth: 2.2 }))
+
+  for (let index = 1; index < 3; index += 1) {
+    const offset = cell * index
+    shapes.push(line(originX + offset, originY, originX + offset, originY + board, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.4 }))
+    shapes.push(line(originX, originY + offset, originX + board, originY + offset, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.4 }))
+  }
+
+  navDurgaCells.forEach((cellDef) => {
+    const cx = originX + cell * cellDef.col + cell / 2
+    const cy = originY + cell * cellDef.row + cell / 2
+    shapes.push(text(cx, cy - 12, cellDef.number, { align: "middle", baseline: "middle", fontSize: 15, fontWeight: "600", letterSpacing: 0.8 }))
+    shapes.push(text(cx, cy + 14, cellDef.title, { align: "middle", baseline: "middle", fontSize: 13, opacity: 0.9 }))
+  })
+
+  return shapes
+}
+
+interface GridPattern {
+  name: string
+  numbers: number[][]
+}
+
+const navagrahaGrids: GridPattern[] = [
+  {
+    name: "JUPITER",
+    numbers: [
+      [10, 5, 11, 8],
+      [7, 9, 6, 12],
+      [13, 16, 14, 15],
+      [4, 3, 1, 2],
+    ],
+  },
+  {
+    name: "MOON",
+    numbers: [
+      [7, 2, 9, 6],
+      [13, 8, 11, 4],
+      [10, 15, 12, 5],
+      [3, 14, 1, 16],
+    ],
+  },
+  {
+    name: "MARS",
+    numbers: [
+      [8, 3, 10, 5],
+      [11, 6, 13, 4],
+      [14, 9, 16, 7],
+      [1, 12, 2, 15],
+    ],
+  },
+  {
+    name: "MERCURY",
+    numbers: [
+      [9, 4, 11, 6],
+      [12, 7, 14, 5],
+      [15, 10, 16, 8],
+      [2, 13, 3, 1],
+    ],
+  },
+  {
+    name: "SUN",
+    numbers: [
+      [6, 1, 8, 3],
+      [11, 16, 9, 14],
+      [10, 15, 12, 5],
+      [7, 4, 13, 2],
+    ],
+  },
+  {
+    name: "VENUS",
+    numbers: [
+      [8, 3, 12, 5],
+      [11, 6, 15, 2],
+      [10, 7, 14, 1],
+      [13, 4, 9, 16],
+    ],
+  },
+  {
+    name: "SATURN",
+    numbers: [
+      [12, 7, 14, 9],
+      [1, 10, 3, 16],
+      [8, 15, 6, 13],
+      [5, 4, 11, 2],
+    ],
+  },
+  {
+    name: "RAHU",
+    numbers: [
+      [7, 2, 13, 4],
+      [10, 15, 6, 11],
+      [9, 14, 5, 12],
+      [8, 3, 16, 1],
+    ],
+  },
+  {
+    name: "KETU",
+    numbers: [
+      [6, 11, 8, 13],
+      [1, 16, 3, 14],
+      [10, 5, 12, 7],
+      [15, 4, 9, 2],
+    ],
+  },
+]
+
+function buildNavagraha(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const gridSize = VIRMANA_CANVAS_SIZE * 0.22
+  const cell = gridSize / 4
+  const gap = 24
+  const totalWidth = gridSize * 3 + gap * 2
+  const startX = center - totalWidth / 2
+  const startY = center - totalWidth / 2
+  const shapes: VirmanaBackdropShape[] = []
+
+  navagrahaGrids.forEach((grid, index) => {
+    const col = index % 3
+    const row = Math.floor(index / 3)
+    const originX = startX + col * (gridSize + gap)
+    const originY = startY + row * (gridSize + gap)
+    shapes.push(rect(originX, originY, gridSize, gridSize, { stroke: "rgba(226,232,240,0.4)", strokeWidth: 1.8, fill: "rgba(12,15,20,0.65)", rx: 10, ry: 10 }))
+
+    for (let step = 1; step < 4; step += 1) {
+      shapes.push(line(originX + cell * step, originY, originX + cell * step, originY + gridSize, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.1 }))
+      shapes.push(line(originX, originY + cell * step, originX + gridSize, originY + cell * step, { stroke: "rgba(148,163,184,0.35)", strokeWidth: 1.1 }))
+    }
+
+    grid.numbers.forEach((rowValues, rowIndex) => {
+      rowValues.forEach((value, colIndex) => {
+        const cx = originX + cell * colIndex + cell / 2
+        const cy = originY + cell * rowIndex + cell / 2
+        shapes.push(text(cx, cy, String(value), { align: "middle", baseline: "middle", fontSize: 14, fontWeight: "600" }))
+      })
+    })
+
+    shapes.push(text(originX + gridSize / 2, originY + gridSize + 20, grid.name, { align: "middle", baseline: "hanging", fontSize: 13, opacity: 0.85, letterSpacing: 0.6 }))
+  })
+
+  return shapes
+}
+
+const weaveBase = [
+  [0, 1, 2, 1, 0, 3, 0, 1],
+  [1, 2, 3, 2, 1, 2, 1, 2],
+  [2, 3, 0, 3, 2, 1, 2, 3],
+  [1, 2, 3, 2, 1, 2, 1, 2],
+  [0, 1, 2, 1, 0, 3, 0, 1],
+  [3, 2, 1, 2, 3, 0, 3, 2],
+  [0, 1, 2, 1, 0, 3, 0, 1],
+  [1, 2, 3, 2, 1, 2, 1, 2],
+]
+
+const weavePalette = ["#0f0f16", "#ef4444", "#facc15", "#2563eb"]
+
+function buildColorWeave(context: VirmanaPatternContext): VirmanaBackdropShape[] {
+  const { center } = context
+  const baseSize = weaveBase.length
+  const cells = baseSize * 2
+  const gridSize = VIRMANA_CANVAS_SIZE * 0.56
+  const cell = gridSize / cells
+  const originX = center - gridSize / 2
+  const originY = center - gridSize / 2
+  const shapes: VirmanaBackdropShape[] = []
+
+  shapes.push(rect(originX - 12, originY - 12, gridSize + 24, gridSize + 24, { stroke: "rgba(255,255,255,0.15)", strokeWidth: 2, fill: "rgba(15,15,19,0.65)" }))
+
+  for (let row = 0; row < cells; row += 1) {
+    const mirroredRow = row < baseSize ? row : baseSize * 2 - 1 - row
+    for (let col = 0; col < cells; col += 1) {
+      const mirroredCol = col < baseSize ? col : baseSize * 2 - 1 - col
+      const colorIndex = weaveBase[mirroredRow][mirroredCol]
+      const fillColor = weavePalette[colorIndex]
+      const x = originX + col * cell
+      const y = originY + row * cell
+      shapes.push(rect(x, y, cell, cell, { fill: fillColor, stroke: "rgba(15,15,19,0.2)", strokeWidth: 0.6 }))
+    }
+  }
+
+  shapes.push(rect(originX, originY, gridSize, gridSize, { stroke: "rgba(244,63,94,0.8)", strokeWidth: 2.4 }))
+
+  return shapes
+}
+
+export const VIRMANA_PATTERNS: VirmanaPattern[] = [
+  {
+    id: "flower-of-life",
+    label: "Flower of Life lattice",
+    description: "Nineteen interlocking petals mapped to a classical Flower of Life grid for harmonic rune spacing.",
+    defaults: {
+      rings: 3,
+      spokes: 12,
+      rotation: 0,
+      deduplicate: true,
+      traceSequence: true,
+      weaveRings: true,
+      mirror: true,
+      axis: false,
+    },
+    showGrid: false,
+    accent: "#38bdf8",
+    build: buildFlowerOfLife,
+  },
+  {
+    id: "metatrons-cube",
+    label: "Metatron cube",
+    description: "Hexahedral light frame weaving seven circles and star tetrahedron lines for transport harmonics.",
+    defaults: {
+      rings: 4,
+      spokes: 12,
+      rotation: 0,
+      deduplicate: true,
+      traceSequence: true,
+      weaveRings: true,
+      mirror: true,
+      axis: true,
+    },
+    showGrid: false,
+    accent: "#60a5fa",
+    build: buildMetatronCube,
+  },
+  {
+    id: "trident-yantra",
+    label: "Trident yantra",
+    description: "Square mandala with trishula sentries and devanagari digits guarding an Om core.",
+    defaults: {
+      rings: 3,
+      spokes: 8,
+      rotation: 0,
+      deduplicate: true,
+      traceSequence: true,
+      weaveRings: false,
+      mirror: false,
+      axis: true,
+    },
+    showGrid: false,
+    accent: "#f8fafc",
+    build: buildTridentYantra,
+  },
+  {
+    id: "architect-mandala",
+    label: "Architect mandala",
+    description: "Nested squares, rotated diamonds, and solar ticks referencing blueprint yantras.",
+    defaults: {
+      rings: 4,
+      spokes: 16,
+      rotation: 0,
+      deduplicate: true,
+      traceSequence: true,
+      weaveRings: true,
+      mirror: true,
+      axis: false,
+    },
+    showGrid: false,
+    accent: "#facc15",
+    build: buildArchitectMandala,
+  },
+  {
+    id: "nav-durga-grid",
+    label: "Nav Durga grid",
+    description: "Nine goddess squares translating syllables into Nav Durga focus points.",
+    defaults: {
+      rings: 3,
+      spokes: 9,
+      rotation: 0,
+      deduplicate: false,
+      traceSequence: false,
+      weaveRings: false,
+      mirror: false,
+      axis: false,
+    },
+    showGrid: false,
+    accent: "#facc15",
+    build: buildNavDurgaGrid,
+  },
+  {
+    id: "navagraha-squares",
+    label: "Navagraha squares",
+    description: "Planetary magic squares for the nine grahas with embedded 4×4 charge matrices.",
+    defaults: {
+      rings: 4,
+      spokes: 12,
+      rotation: 0,
+      deduplicate: true,
+      traceSequence: true,
+      weaveRings: false,
+      mirror: true,
+      axis: false,
+    },
+    showGrid: false,
+    accent: "#93c5fd",
+    build: buildNavagraha,
+  },
+  {
+    id: "color-weave",
+    label: "Rangoli weave",
+    description: "Symmetric rangoli mosaic inspired by temple floor bindings for energy balancing.",
+    defaults: {
+      rings: 4,
+      spokes: 16,
+      rotation: 0,
+      deduplicate: false,
+      traceSequence: true,
+      weaveRings: true,
+      mirror: true,
+      axis: false,
+    },
+    showGrid: false,
+    accent: "#ef4444",
+    build: buildColorWeave,
+  },
+]
+

--- a/src/lib/glyph/virmana.ts
+++ b/src/lib/glyph/virmana.ts
@@ -1,0 +1,366 @@
+import type { RuneDef } from "@/lib/data/runes"
+import { polarToCartesian } from "@/lib/glyph/mandala"
+import { renderRune } from "@/lib/glyph/render"
+
+export const VIRMANA_CANVAS_SIZE = 640
+
+export interface VirmanaPlacement {
+  rune: RuneDef
+  angle: number
+  radius: number
+  ringIndex: number
+  spokeIndex: number
+}
+
+export interface VirmanaOptions {
+  rings: number
+  spokes: number
+  rotation: number
+}
+
+export interface VirmanaConnectionOptions {
+  traceSequence: boolean
+  weaveRings: boolean
+  mirror: boolean
+  axis: boolean
+}
+
+export interface VirmanaPoint {
+  x: number
+  y: number
+}
+
+interface BackdropBase {
+  stroke?: string
+  fill?: string
+  strokeWidth?: number
+  opacity?: number
+  dashArray?: string
+  strokeLinecap?: "round" | "square" | "butt"
+}
+
+export interface VirmanaBackdropCircle extends BackdropBase {
+  type: "circle"
+  cx: number
+  cy: number
+  r: number
+}
+
+export interface VirmanaBackdropLine extends BackdropBase {
+  type: "line"
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
+
+export interface VirmanaBackdropPolygon extends BackdropBase {
+  type: "polygon"
+  points: VirmanaPoint[]
+}
+
+export interface VirmanaBackdropRect extends BackdropBase {
+  type: "rect"
+  x: number
+  y: number
+  width: number
+  height: number
+  rx?: number
+  ry?: number
+}
+
+export interface VirmanaBackdropPath extends BackdropBase {
+  type: "path"
+  d: string
+}
+
+export interface VirmanaBackdropText {
+  type: "text"
+  x: number
+  y: number
+  text: string
+  fill?: string
+  opacity?: number
+  fontSize?: number
+  fontWeight?: string
+  letterSpacing?: number
+  align?: "start" | "middle" | "end"
+  baseline?: "hanging" | "middle" | "baseline" | "alphabetic"
+  fontFamily?: string
+}
+
+export type VirmanaBackdropShape =
+  | VirmanaBackdropCircle
+  | VirmanaBackdropLine
+  | VirmanaBackdropPolygon
+  | VirmanaBackdropRect
+  | VirmanaBackdropPath
+  | VirmanaBackdropText
+
+export interface VirmanaSvgConfig {
+  canvas?: number
+  backdrop?: VirmanaBackdropShape[]
+  includeGrid?: boolean
+}
+
+export interface CartesianPoint {
+  x: number
+  y: number
+}
+
+export interface VirmanaLayout {
+  placements: VirmanaPlacement[]
+  center: number
+}
+
+export type VirmanaConnection = {
+  start: CartesianPoint
+  end: CartesianPoint
+}
+
+function clampOptions(options: VirmanaOptions): VirmanaOptions {
+  return {
+    rings: Math.max(1, Math.min(5, Math.round(options.rings))),
+    spokes: Math.max(3, Math.round(options.spokes)),
+    rotation: ((options.rotation % 360) + 360) % 360,
+  }
+}
+
+export function computeRingRadii(rings: number, canvas: number = VIRMANA_CANVAS_SIZE) {
+  const center = canvas / 2
+  if (rings <= 0) {
+    return []
+  }
+  const maxRadius = center - 56
+  const step = maxRadius / rings
+  return Array.from({ length: rings }, (_, index) => +(step * (index + 1)).toFixed(2))
+}
+
+interface Spot {
+  angle: number
+  radius: number
+  ringIndex: number
+  spokeIndex: number
+}
+
+function generateSpots(options: VirmanaOptions, canvas: number = VIRMANA_CANVAS_SIZE): Spot[] {
+  const { rings, spokes, rotation } = clampOptions(options)
+  const radii = computeRingRadii(rings, canvas)
+  const angleStep = 360 / spokes
+  const angles = Array.from({ length: spokes }, (_, index) => rotation + index * angleStep)
+  const spots: Spot[] = []
+
+  radii.forEach((radius, ringIndex) => {
+    angles.forEach((angle, spokeIndex) => {
+      spots.push({ angle: +angle.toFixed(2), radius, ringIndex, spokeIndex })
+    })
+  })
+
+  return spots
+}
+
+export function buildPlacements(
+  runes: RuneDef[],
+  options: VirmanaOptions,
+  canvas: number = VIRMANA_CANVAS_SIZE,
+): VirmanaLayout {
+  const spots = generateSpots(options, canvas)
+  const center = canvas / 2
+  if (runes.length === 0) {
+    return { placements: [], center }
+  }
+
+  if (spots.length === 0) {
+    throw new Error("Virmana requires at least one ring and one spoke")
+  }
+
+  const placements: VirmanaPlacement[] = []
+
+  if (runes.length <= spots.length) {
+    const available = [...spots]
+    runes.forEach((rune, index) => {
+      const pickIndex = (rune.numericMap + index) % available.length
+      const [spot] = available.splice(pickIndex, 1)
+      placements.push({ rune, ...spot })
+    })
+  } else {
+    runes.forEach((rune, index) => {
+      const spot = spots[(rune.numericMap + index) % spots.length]
+      placements.push({ rune, ...spot })
+    })
+  }
+
+  return { placements, center }
+}
+
+function mirrorPoint(point: CartesianPoint, center: number): CartesianPoint {
+  return { x: +(center * 2 - point.x).toFixed(2), y: point.y }
+}
+
+export function computeConnections(
+  layout: VirmanaLayout,
+  options: VirmanaConnectionOptions,
+): VirmanaConnection[] {
+  const { placements, center } = layout
+  if (placements.length === 0) {
+    return []
+  }
+
+  const points = placements.map((placement) =>
+    polarToCartesian({ radius: placement.radius, angle: placement.angle }, { x: center, y: center }),
+  )
+
+  const lines: VirmanaConnection[] = []
+
+  if (options.traceSequence && placements.length > 1) {
+    for (let index = 0; index < placements.length; index += 1) {
+      const start = points[index]
+      const end = points[(index + 1) % placements.length]
+      lines.push({ start, end })
+    }
+  }
+
+  if (options.weaveRings) {
+    const byRing = new Map<number, { point: CartesianPoint; angle: number }[]>()
+    placements.forEach((placement, index) => {
+      const bucket = byRing.get(placement.ringIndex) ?? []
+      bucket.push({ point: points[index], angle: placement.angle })
+      byRing.set(placement.ringIndex, bucket)
+    })
+    byRing.forEach((bucket) => {
+      if (bucket.length < 2) return
+      const sorted = bucket.sort((a, b) => a.angle - b.angle)
+      for (let index = 0; index < sorted.length; index += 1) {
+        const start = sorted[index].point
+        const end = sorted[(index + 1) % sorted.length].point
+        lines.push({ start, end })
+      }
+    })
+  }
+
+  if (options.axis) {
+    points.forEach((point) => {
+      lines.push({ start: point, end: { x: center, y: center } })
+    })
+  }
+
+  if (options.mirror) {
+    const mirrored = lines.map((line) => ({
+      start: mirrorPoint(line.start, center),
+      end: mirrorPoint(line.end, center),
+    }))
+    return [...lines, ...mirrored]
+  }
+
+  return lines
+}
+
+function renderCommonAttributes(shape: BackdropBase) {
+  const stroke = shape.stroke ? ` stroke="${shape.stroke}"` : ""
+  const fill = shape.fill ? ` fill="${shape.fill}"` : " fill="none"`
+  const strokeWidth = shape.strokeWidth ? ` stroke-width="${shape.strokeWidth}"` : ""
+  const opacity = typeof shape.opacity === "number" ? ` opacity="${shape.opacity}"` : ""
+  const dashArray = shape.dashArray ? ` stroke-dasharray="${shape.dashArray}"` : ""
+  const linecap = shape.strokeLinecap ? ` stroke-linecap="${shape.strokeLinecap}"` : ""
+  return `${stroke}${fill}${strokeWidth}${opacity}${dashArray}${linecap}`
+}
+
+function escapeText(value: string) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+function pointListToString(points: VirmanaPoint[]) {
+  return points.map((point) => `${point.x.toFixed(2)},${point.y.toFixed(2)}`).join(" ")
+}
+
+function convertBackdropToSvg(shapes: VirmanaBackdropShape[]): string {
+  return shapes
+    .map((shape) => {
+      switch (shape.type) {
+        case "circle":
+          return `<circle cx="${shape.cx.toFixed(2)}" cy="${shape.cy.toFixed(2)}" r="${shape.r.toFixed(2)}"${renderCommonAttributes(shape)} />`
+        case "line":
+          return `<line x1="${shape.x1.toFixed(2)}" y1="${shape.y1.toFixed(2)}" x2="${shape.x2.toFixed(2)}" y2="${shape.y2.toFixed(2)}"${renderCommonAttributes(shape)} />`
+        case "polygon":
+          return `<polygon points="${pointListToString(shape.points)}"${renderCommonAttributes(shape)} />`
+        case "rect": {
+          const rx = shape.rx ? ` rx="${shape.rx.toFixed(2)}"` : ""
+          const ry = shape.ry ? ` ry="${shape.ry.toFixed(2)}"` : ""
+          return `<rect x="${shape.x.toFixed(2)}" y="${shape.y.toFixed(2)}" width="${shape.width.toFixed(2)}" height="${shape.height.toFixed(2)}"${rx}${ry}${renderCommonAttributes(shape)} />`
+        }
+        case "path":
+          return `<path d="${shape.d}"${renderCommonAttributes(shape)} />`
+        case "text": {
+          const fill = shape.fill ? ` fill="${shape.fill}"` : " fill="rgba(226,232,240,0.85)"`
+          const opacity = typeof shape.opacity === "number" ? ` opacity="${shape.opacity}"` : ""
+          const fontSize = shape.fontSize ? ` font-size="${shape.fontSize}"` : ""
+          const fontWeight = shape.fontWeight ? ` font-weight="${shape.fontWeight}"` : ""
+          const letterSpacing = typeof shape.letterSpacing === "number" ? ` letter-spacing="${shape.letterSpacing}"` : ""
+          const textAnchor = shape.align ? ` text-anchor="${shape.align}"` : ""
+          const baseline = shape.baseline ? ` dominant-baseline="${shape.baseline}"` : ""
+          const fontFamily = shape.fontFamily ? ` font-family="${shape.fontFamily}"` : ""
+          return `<text x="${shape.x.toFixed(2)}" y="${shape.y.toFixed(2)}"${fill}${opacity}${fontSize}${fontWeight}${letterSpacing}${textAnchor}${baseline}${fontFamily}>${escapeText(shape.text)}</text>`
+        }
+        default:
+          return ""
+      }
+    })
+    .join("\n")
+}
+
+export function buildVirmanaSvg(
+  layout: VirmanaLayout,
+  options: VirmanaOptions,
+  connections: VirmanaConnection[],
+  config: VirmanaSvgConfig = {},
+): string {
+  const canvas = config.canvas ?? VIRMANA_CANVAS_SIZE
+  const center = canvas / 2
+  const runes = layout.placements
+  const includeGrid = config.includeGrid ?? true
+
+  const circles = includeGrid
+    ? computeRingRadii(options.rings, canvas)
+        .map(
+          (radius) =>
+            `<circle cx="${center}" cy="${center}" r="${radius}" fill="none" stroke="rgba(148,163,184,0.28)" stroke-dasharray="14 12" />`,
+        )
+        .join("\n")
+    : ""
+
+  const angleStep = 360 / Math.max(1, options.spokes)
+  const spokes = includeGrid
+    ? Array.from({ length: options.spokes }, (_, index) => options.rotation + index * angleStep)
+        .map((angle) => {
+          const { x, y } = polarToCartesian({ radius: center - 40, angle }, { x: center, y: center })
+          return `<line x1="${center}" y1="${center}" x2="${x}" y2="${y}" stroke="rgba(148,163,184,0.24)" stroke-dasharray="12 10" />`
+        })
+        .join("\n")
+    : ""
+
+  const connectionLines = connections
+    .map((connection) =>
+      `<line x1="${connection.start.x}" y1="${connection.start.y}" x2="${connection.end.x}" y2="${connection.end.y}" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" stroke-opacity="0.65" />`,
+    )
+    .join("\n")
+
+  const backdrop = config.backdrop ? convertBackdropToSvg(config.backdrop) : ""
+
+  const runeGroups = runes
+    .map((placement) => {
+      const { x, y } = polarToCartesian({ radius: placement.radius, angle: placement.angle }, { x: center, y: center })
+      const svg = layoutPlacementsRune(placement.rune)
+      const offsetX = x - 60
+      const offsetY = y - 60
+      return `<g transform="translate(${offsetX},${offsetY})">${svg}</g>`
+    })
+    .join("\n")
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${canvas} ${canvas}" width="${canvas}" height="${canvas}" role="img">\n<rect x="0" y="0" width="${canvas}" height="${canvas}" fill="rgb(15,15,19)" />\n${backdrop}\n${circles}\n${spokes}\n${connectionLines}\n${runeGroups}\n</svg>`
+}
+
+function layoutPlacementsRune(rune: RuneDef) {
+  const svg = renderRune(rune, { size: 120, strokeWidth: 10, strokeColor: "#f8fafc" })
+  const match = svg.match(/<g[\s\S]*<\/g>/)
+  return match ? match[0] : svg
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
         <div className="space-y-4">
           <h1 className="text-4xl font-semibold">New Runes Glyph Laboratory</h1>
           <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
-            Explore the full 29-rune alphabet, compose script lines with live gematria sums, and assemble radial sigils that obey the chisel law. Everything renders to lawful SVG that you can export instantly.
+            Explore the full 29-rune alphabet, compose script lines with live gematria sums, and assemble radial sigils that obey the chisel law. The Virmana forge now spans Flower of Life petals, Metatron cubes, Nav Durga grids, Navagraha magic squares, and rangoli mosaics—everything renders to lawful SVG that you can export instantly.
           </p>
         </div>
         <div className="flex flex-wrap justify-center gap-3">
@@ -32,6 +32,11 @@ export default function HomePage() {
           <Button asChild variant="ghost">
             <Link to="/mandala" className="flex items-center gap-2">
               Craft a mandala <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+          <Button asChild variant="ghost">
+            <Link to="/virmana" className="flex items-center gap-2">
+              Forge a virmana <ArrowRight className="h-4 w-4" />
             </Link>
           </Button>
         </div>

--- a/src/pages/Virmana.tsx
+++ b/src/pages/Virmana.tsx
@@ -1,0 +1,16 @@
+import { VirmanaForge } from "@/components/VirmanaForge"
+
+export default function VirmanaPage() {
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-3 rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-black/20">
+        <h1 className="text-3xl font-semibold">Virmana Forge</h1>
+        <p className="text-muted-foreground">
+          Translate a mantra into a transport lattice. Choose from Flower of Life petals, Metatron cubes, trident yantras,
+          Navagraha squares, and rangoli mosaics, then project each rune onto the geometry for exportable SVG or PNG sigils.
+        </p>
+      </section>
+      <VirmanaForge />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a library of sacred-geometry Virmana patterns including Flower of Life, Metatron cube, yantras, Navagraha squares, and rangoli mosaics
- update the forge UI to select patterns, apply accent colors, and render/export the associated backdrop geometry
- refresh Virmana and home copy to highlight the new geometry presets

## Testing
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cfdc2056e0832f87ab26eed1edc2af